### PR TITLE
Fix invalid timestamp handling

### DIFF
--- a/modules/caching.py
+++ b/modules/caching.py
@@ -12,7 +12,10 @@ REFRESH_INTERVAL_HOURS = 24
 def check_and_refresh_data():
     last_refresh_str = get_metadata('last_refresh')
     if last_refresh_str:
-        last_refresh = datetime.datetime.fromisoformat(last_refresh_str)
+        try:
+            last_refresh = datetime.datetime.fromisoformat(last_refresh_str)
+        except ValueError:
+            last_refresh = None
     else:
         last_refresh = None
 


### PR DESCRIPTION
## Summary
- handle `ValueError` from `datetime.fromisoformat`

## Testing
- `python -m py_compile modules/caching.py`
